### PR TITLE
Add/relationship linkage tests#40

### DIFF
--- a/test/belongsTo.test.js
+++ b/test/belongsTo.test.js
@@ -304,7 +304,7 @@ describe('loopback json api hasOne relationships', function () {
 
     describe.skip('delete linkages to models as part of an update operation', function () {
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1')
+        request(app).patch('/posts/1')
           .send({
             data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
             relationships: {comments: {data: []}}
@@ -331,7 +331,7 @@ describe('loopback json api hasOne relationships', function () {
         }, done);
       });
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1').send({
+        request(app).patch('/posts/1').send({
           data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
           relationships: {comments: {data: [
             {type: 'comments', id: 1},

--- a/test/belongsTo.test.js
+++ b/test/belongsTo.test.js
@@ -278,5 +278,74 @@ describe('loopback json api hasOne relationships', function () {
           });
       });
     });
+
+    describe.skip('link related models as part of a create operation', function () {
+      it('should create and link models', function (done) {
+        request(app).post('/posts')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {comments: {data: [
+              {type: 'comments', id: 1}
+            ]}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            Comment.findById(1, function (err, comment) {
+              expect(err).to.equal(null);
+              expect(comment).not.to.equal(null);
+              expect(comment.postId).to.equal(2);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('delete linkages to models as part of an update operation', function () {
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {comments: {data: []}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            Comment.findById(1, function (err, comment) {
+              expect(err).to.equal(null);
+              expect(comment).not.to.equal(null);
+              expect(comment.postId).to.equal(null);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('replace linkages as part of an update operation', function () {
+      beforeEach(function (done) {
+        Comment.create({
+          title: 'my comment 2',
+          comment: 'my post comment 2'
+        }, done);
+      });
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1').send({
+          data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+          relationships: {comments: {data: [
+            {type: 'comments', id: 1},
+            {type: 'comments', id: 2}
+          ]}}
+        })
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/json')
+        .end(function (err, res) {
+          Comment.find({postId: 1}, function (err, comments) {
+            expect(err).to.equal(null);
+            expect(comments.length).to.equal(2);
+            done();
+          });
+        });
+      });
+    });
   });
 });

--- a/test/belongsTo.test.js
+++ b/test/belongsTo.test.js
@@ -291,6 +291,7 @@ describe('loopback json api hasOne relationships', function () {
           .set('Accept', 'application/vnd.api+json')
           .set('Content-Type', 'application/json')
           .end(function (err, res) {
+            expect(err).to.equal(null);
             Comment.findById(1, function (err, comment) {
               expect(err).to.equal(null);
               expect(comment).not.to.equal(null);
@@ -311,6 +312,7 @@ describe('loopback json api hasOne relationships', function () {
           .set('Accept', 'application/vnd.api+json')
           .set('Content-Type', 'application/json')
           .end(function (err, res) {
+            expect(err).to.equal(null);
             Comment.findById(1, function (err, comment) {
               expect(err).to.equal(null);
               expect(comment).not.to.equal(null);
@@ -339,6 +341,7 @@ describe('loopback json api hasOne relationships', function () {
         .set('Accept', 'application/vnd.api+json')
         .set('Content-Type', 'application/json')
         .end(function (err, res) {
+          expect(err).to.equal(null);
           Comment.find({postId: 1}, function (err, comments) {
             expect(err).to.equal(null);
             expect(comments.length).to.equal(2);

--- a/test/hasMany.test.js
+++ b/test/hasMany.test.js
@@ -257,5 +257,77 @@ describe('loopback json api hasMany relationships', function () {
           .end(done);
       });
     });
+
+    describe.skip('link related models as part of a create operation', function () {
+      it('should create and link models', function (done) {
+        request(app).post('/posts')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {comments: {data: [
+              {type: 'comments', id: 1}
+            ]}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            expect(err).to.equal(null);
+            Comment.findById(1, function (err, comment) {
+              expect(err).to.equal(null);
+              expect(comment).not.to.equal(null);
+              expect(comment.postId).to.equal(2);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('delete linkages to models as part of an update operation', function () {
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {comments: {data: []}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            expect(err).to.equal(null);
+            Comment.findById(1, function (err, comment) {
+              expect(err).to.equal(null);
+              expect(comment).not.to.equal(null);
+              expect(comment.postId).to.equal(null);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('replace linkages as part of an update operation', function () {
+      beforeEach(function (done) {
+        Comment.create({
+          title: 'my comment 2',
+          comment: 'my post comment 2'
+        }, done);
+      });
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1').send({
+          data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+          relationships: {comments: {data: [
+            {type: 'comments', id: 1},
+            {type: 'comments', id: 2}
+          ]}}
+        })
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/json')
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          Comment.find({postId: 1}, function (err, comments) {
+            expect(err).to.equal(null);
+            expect(comments.length).to.equal(2);
+            done();
+          });
+        });
+      });
+    });
   });
 });

--- a/test/hasMany.test.js
+++ b/test/hasMany.test.js
@@ -283,7 +283,7 @@ describe('loopback json api hasMany relationships', function () {
 
     describe.skip('delete linkages to models as part of an update operation', function () {
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1')
+        request(app).patch('/posts/1')
           .send({
             data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
             relationships: {comments: {data: []}}
@@ -310,7 +310,7 @@ describe('loopback json api hasMany relationships', function () {
         }, done);
       });
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1').send({
+        request(app).patch('/posts/1').send({
           data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
           relationships: {comments: {data: [
             {type: 'comments', id: 1},

--- a/test/hasOne.test.js
+++ b/test/hasOne.test.js
@@ -258,5 +258,70 @@ describe('loopback json api hasOne relationships', function () {
           .end(done);
       });
     });
+
+    describe.skip('link related models as part of a create operation', function () {
+      it('should create and link models', function (done) {
+        request(app).post('/posts')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {author: {data: {type: 'people', id: 1}}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            expect(err).to.equal(null);
+            Person.findById(1, function (err, person) {
+              expect(err).to.equal(null);
+              expect(person).not.to.equal(null);
+              expect(person.postId).to.equal(2);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('delete linkages to models as part of an update operation', function () {
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1')
+          .send({
+            data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+            relationships: {author: {data: null}}
+          })
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .end(function (err, res) {
+            expect(err).to.equal(null);
+            Person.findById(1, function (err, person) {
+              expect(err).to.equal(null);
+              expect(person).not.to.equal(null);
+              expect(person.postId).to.equal(null);
+              done();
+            });
+          });
+      });
+    });
+
+    describe.skip('replace linkages as part of an update operation', function () {
+      beforeEach(function (done) {
+        Person.create({name: 'Rachel McAdams'}, done);
+      });
+      it('should update model linkages', function (done) {
+        request(app).put('/posts/1').send({
+          data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
+          relationships: {author: {data: {type: 'people', id: 2}}}
+        })
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/json')
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          Person.find({postId: 1}, function (err, people) {
+            expect(err).to.equal(null);
+            expect(people.length).to.equal(1);
+            expect(people[0].id).to.equal(2);
+            done();
+          });
+        });
+      });
+    });
   });
 });

--- a/test/hasOne.test.js
+++ b/test/hasOne.test.js
@@ -282,7 +282,7 @@ describe('loopback json api hasOne relationships', function () {
 
     describe.skip('delete linkages to models as part of an update operation', function () {
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1')
+        request(app).patch('/posts/1')
           .send({
             data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
             relationships: {author: {data: null}}
@@ -306,7 +306,7 @@ describe('loopback json api hasOne relationships', function () {
         Person.create({name: 'Rachel McAdams'}, done);
       });
       it('should update model linkages', function (done) {
-        request(app).put('/posts/1').send({
+        request(app).patch('/posts/1').send({
           data: {type: 'posts', attributes: {title: 'my post', content: 'my post content' }},
           relationships: {author: {data: {type: 'people', id: 2}}}
         })


### PR DESCRIPTION
Add tests for creating, updating and deleting relationship linkages as part of a create (POST) or update (PUT) operation on the main model.

See #40 for details

Tests are set to skip for now. Ready to be worked on by whomever.