### PR TITLE
#49 fixing multi-resource requests from not having correct self links

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -207,15 +207,17 @@ function makeRelations (type, ids, options) {
  * @return {Object}
  */
 function makeLinks (links, item) {
+  var retLinks = {};
+
   _.each(links, function (value, name) {
     if (_.isFunction(value)) {
-      links[name] = value(item);
+      retLinks[name] = value(item);
     } else {
-      links[name] = _(value).toString();
+      retLinks[name] = _(value).toString();
     }
   });
 
-  return links;
+  return retLinks;
 }
 
 /**


### PR DESCRIPTION
This fixes the self link in each resource for /posts not having the correct link and using the first link's value.