### PR TITLE
Improve readme and remove case option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,36 @@ In your loopback project:
 3. Add the following config to `component-config.json`
 ```json
 {
+  "loopback-component-jsonapi": {}
+}
+```
+
+## Advanced usage:
+In a fairly limited way, you can configure a how the component behaves.
+
+Example:
+```json
+{
   "loopback-component-jsonapi": {
     "restApiRoot": "/api",
-    "enable": true,
-    "keyForAttribute": "dash-case",
-    "keyForType": "dash-case",
-    "keyForRelation": "dash-case"
+    "enable": true
   }
 }
+```
+### restApiRoot
+Url prefix to be used in conjunction with host and resource paths.
+eg. http://127.0.0.1:3214/api/people
+Default: `/api`
+
+### enable
+Whether the component should be enabled or disabled.
+Default: true
+
+## Debugging
+You can enable debug logging by setting an environment variable:
+DEBUG=loopback-component-jsonapi
+
+Example:
+```
+DEBUG=loopback-component-jsonapi node .
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,10 +15,7 @@ var debug = require('debug')('loopback-component-jsonapi');
 module.exports = function (app, options) {
   var defaultOptions = {
     restApiRoot: '/api',
-    enable: true,
-    keyForAttribute: 'dash-case',
-    keyForType: 'dash-case',
-    keyForRelation: 'dash-case'
+    enable: true
   };
   options = options || {};
   options = _.defaults(options, defaultOptions);

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -18,10 +18,10 @@ var regexs = [
 module.exports = function (app, defaults) {
   app.remotes().after('**', function (ctx, next) {
     var data,
-      modelName,
       type,
       options,
       relatedModelName,
+      modelNamePlural,
       relatedModelPlural,
       relations,
       res;
@@ -48,8 +48,8 @@ module.exports = function (app, defaults) {
     }
 
     data = utils.clone(ctx.result);
-    modelName = utils.modelNameFromContext(ctx);
-    type = modelName;
+    modelNamePlural = utils.pluralForModel(utils.getModelFromContext(ctx, app));
+    type = modelNamePlural;
 
     /**
      * HACK: specifically when data is null and GET :model/:id
@@ -89,7 +89,7 @@ module.exports = function (app, defaults) {
           if (relatedModelPlural) {
             args.push(relatedModelPlural);
           } else {
-            args.push(utils.pluralForModel(app.models[modelName]));
+            args.push(modelNamePlural);
           }
 
           args.push(item.id);

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var inflection = require('inflection');
 var utils = require('./utils');
 
 module.exports = function serializer (type, data, relations, options) {
@@ -44,8 +43,6 @@ function parseResource (type, data, relations, options) {
   var attributes = {};
   var relationships;
 
-  type = inflection.pluralize(type);
-  type = caserize(type, options.keyForRelation);
   resource.type = type;
   relationships = parseRelations(data, relations, options);
 
@@ -57,7 +54,6 @@ function parseResource (type, data, relations, options) {
     if (property === 'id') {
       resource.id = _(value).toString();
     } else {
-      property = caserize(property, options.keyForAttribute);
       attributes[property] = value;
     }
   });
@@ -141,7 +137,6 @@ function parseRelations (data, relations, options) {
     var pk = data[pkName];
     var fk = data[fkName];
 
-    name = caserize(name, options.keyForRelation);
     var fromType = utils.pluralForModel(relation.modelFrom);
     var toType = utils.pluralForModel(relation.modelTo);
 
@@ -193,7 +188,7 @@ function makeRelation (type, id, options) {
   }
 
   return {
-    type: caserize(type, options.keyForRelation),
+    type: type,
     id: id
   };
 }
@@ -237,24 +232,4 @@ function makeLinks (links, item) {
   });
 
   return retLinks;
-}
-
-/**
- * Handles converting string cases.
- * @param {String} value
- * @param {String} type
- * @return {String}
- */
-function caserize (value, type) {
-  type = type || 'dash-case';
-
-  var mapping = {
-    'dash-case': _.kebabCase,
-    'underscore_case': inflection.underscore,
-    'camelCase': _.camelCase,
-    'Classify': inflection.classify
-  };
-
-  var func = mapping[type];
-  return func(value);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,10 @@ module.exports = {
  * @return {String}
  */
 function pluralForModel (model) {
+  if (model.pluralModelName) {
+    return model.pluralModelName;
+  }
+
   if (model.settings && model.settings.http && model.settings.http.path) {
     return model.settings.http.path;
   }


### PR DESCRIPTION
This started out as an improvement to the `case` option but ended up being a total removal instead.

Reasoning:
- You can define what sort of case you like by defining your model.json file properties how you like
- Adds complexity
- Cases Introduces issues with url links where a url needs to be a certain way and if you change its case the link no longer works.

If this is a feature that we would like to have then I suggest we propose/add it at a later stage when the component is more mature. My feeling personally is that it's not our concern and we don't need it.