### PR TITLE
Added support camelCase properties

### DIFF
--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -12,6 +12,9 @@ var inflection = require('inflection');
 module.exports = function deserializer (data, serverRelations) {
   var clientRelations = data.data.relationships;
   var result = data.data.attributes || {};
+  result = _.mapKeys(result, function (value, key) {
+    return _.camelCase(key);
+  });
 
   if (_.isPlainObject(clientRelations)) {
     _.each(clientRelations, function (relation, name) {
@@ -64,6 +67,7 @@ function handleClientRelations (data, result, serverRelation, clientRelation) {
     } else {
       relationType = inflection.singularize(relationType);
       if (relationType !== serverRelation.model) {
+        //TODO: Maybe throw a 400 error?
         return;
       }
     }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -54,6 +54,7 @@ function parseResource (type, data, relations, options) {
     if (property === options.primaryKeyField) {
       resource.id = _(value).toString();
     } else {
+      property = _.kebabCase(property);
       attributes[property] = value;
     }
   });

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -149,8 +149,9 @@ describe('loopback json api component create method', function () {
           expect(res.body.data).to.have.all.keys('id', 'type', 'attributes', 'links');
           expect(res.body.data.id).to.equal('1');
           expect(res.body.data.type).to.equal('posts');
-          expect(res.body.data.attributes).to.have.all.keys('title', 'content', 'isDraft');
+          expect(res.body.data.attributes).to.have.all.keys('title', 'content', 'is-draft');
           expect(res.body.data.attributes).to.not.have.keys('id');
+          expect(res.body.data.attributes['is-draft']).to.equal(true);
           done();
         });
     });

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -14,7 +14,8 @@ describe('loopback json api component create method', function () {
     Post = ds.createModel('post', {
       id: {type: Number, id: true},
       title: String,
-      content: String
+      content: String,
+      isDraft: Boolean
     });
     app.model(Post);
     app.use(loopback.rest());
@@ -136,7 +137,8 @@ describe('loopback json api component create method', function () {
             type: 'posts',
             attributes: {
               title: 'my post',
-              content: 'my post content'
+              content: 'my post content',
+              'is-draft': true
             }
           }
         })
@@ -147,7 +149,7 @@ describe('loopback json api component create method', function () {
           expect(res.body.data).to.have.all.keys('id', 'type', 'attributes', 'links');
           expect(res.body.data.id).to.equal('1');
           expect(res.body.data.type).to.equal('posts');
-          expect(res.body.data.attributes).to.have.all.keys('title', 'content');
+          expect(res.body.data.attributes).to.have.all.keys('title', 'content', 'isDraft');
           expect(res.body.data.attributes).to.not.have.keys('id');
           done();
         });


### PR DESCRIPTION
@digitalsadhu please make review
See http://jsonapi.org/recommendations/
> Member names SHOULD contain only the characters "a-z" (U+0061 to U+007A), "0-9" (U+0030 to U+0039), and the hyphen minus (U+002D HYPHEN-MINUS, "-") as separator between multiple words.

https://docs.strongloop.com/display/public/LB/Model+definition+JSON+file#ModeldefinitionJSONfile-Generalpropertyproperties

* Request: ```kebabCase => camelCase```
* Response: ```camelCase => kebabCase```
