### PR TITLE
Added failing test for user login test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chai": "^3.3.0",
     "eslint": "^1.6.0",
     "loopback": "^2.22.2",
+    "loopback-boot": "^2.16.0",
     "loopback-datasource-juggler": "^2.40.1",
     "mocha": "^2.3.3",
     "supertest": "^1.1.0",

--- a/test/fixtures/user-app/server/config.json
+++ b/test/fixtures/user-app/server/config.json
@@ -1,0 +1,15 @@
+{
+  "port": 3000,
+  "host": "0.0.0.0",
+  "cookieSecret": "2d13a01d-44fb-455c-80cb-db9cb3cd3cd0",
+  "remoting": {
+    "json": {
+      "limit": "1kb",
+      "strict": false
+    },
+    "urlencoded": {
+      "limit": "8kb"
+    }
+  },
+  "legacyExplorer": false
+}

--- a/test/fixtures/user-app/server/datasources.json
+++ b/test/fixtures/user-app/server/datasources.json
@@ -1,0 +1,5 @@
+{
+  "db": {
+    "connector": "memory"
+  }
+}

--- a/test/fixtures/user-app/server/model-config.json
+++ b/test/fixtures/user-app/server/model-config.json
@@ -1,0 +1,27 @@
+{
+  "_meta": {
+    "sources": [
+      "./models"
+    ]
+  },
+  "User": {
+    "dataSource": "db",
+    "public": true
+  },
+  "AccessToken": {
+    "dataSource": "db",
+    "public": false
+  },
+  "ACL": {
+    "dataSource": "db",
+    "public": false
+  },
+  "RoleMapping": {
+    "dataSource": "db",
+    "public": false
+  },
+  "Role": {
+    "dataSource": "db",
+    "public": false
+  }
+}

--- a/test/fixtures/user-app/server/server.js
+++ b/test/fixtures/user-app/server/server.js
@@ -1,0 +1,7 @@
+var loopback = require('loopback');
+var boot = require('loopback-boot');
+var app = module.exports = loopback();
+app.enableAuth();
+boot(app, __dirname);
+app.use(loopback.token({model: app.models.AccessToken}));
+app.use('/', loopback.rest());

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,0 +1,35 @@
+var request = require('supertest');
+var expect = require('chai').expect;
+var JSONAPIComponent = require('../');
+var path = require('path');
+var USER_APP = path.join(__dirname, 'fixtures', 'user-app');
+var app;
+
+describe('new user registration', function () {
+  beforeEach(function () {
+    app = require(path.join(USER_APP, 'server/server.js'));
+    JSONAPIComponent(app);
+  });
+
+  it('should create a new user and return a sideloaded accessToken', function (done) {
+    request(app)
+      .post('/Users')
+      .send({
+        data: {
+          type: 'User',
+          attributes: {
+            email: 'foo@example.com',
+            password: 'foo'
+          }
+        }
+      })
+      .set('Content-Type', 'application/json')
+      .expect(201)
+      .end(function (err, res) {
+        expect(err).to.equal(null);
+        expect(res.body).to.have.deep.property('data.id', '1');
+        expect(res.body).to.have.deep.property('data.relationships.accessTokens.data[0].id');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
- new user registration should return a sideloaded accessToken, instead it returns a link to related accessToken
- Added loopback-boot - necessary to load fixture data
- Added fixtures directory with app fixture because default User is not public
- Added fixtures for testing authentication