### PR TITLE
Add support for custom serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,62 +244,149 @@ module.exports = function (MyModel) {
 ```
 
 ##### function parameters
-- `options` All config options set for the serialization process
-  - `options.type`
-  - `options.model`
-  - `options.method`
-  - `options.primaryKeyField`
-  - `options.requestedIncludes`
-  - `options.host`
-  - `options.topLevelLinks`
-  - `options.dataLinks`
-  - `options.relationships`
-  - `options.results`
-  - `options.restApiRoot`
-  - `options.enable`
-  - `options.handleErrors`
-  - `options.exclude`
-  - `options.hideIrrelevantMethods`
-  - `options.attributes`
+
+- `options` All config options set for the serialization process. See below.
 - `callback` Callback to call with error or serialized records
+
+###### `options.type`
+Resource type. Originally calculated from a models plural. Is used in the default
+serialization process to set the type property for each model in a jsonapi response.
+- eg. `posts`
+
+###### `options.method`
+The method that was called to get the data for the current request. This is not
+used in the serialization process but is provided for custom hook and serialization
+context.
+- Eg. `create`, `updateAttributes`
+
+###### `options.primaryKeyField`
+The name of the property that is the primary key for the model. This is usually just
+`id` unless defined differently in a model.json file.
+
+###### `options.requestedIncludes`
+The relationships that the user has requested be side loaded with the request.
+For example, for the request `GET /api/posts?include=comments` options.requestedIncludes
+would be `'comments'`.
+- Type: `string` or `array`
+- eg: `'comments'` or `['posts', 'comments']`
+
+###### `options.host`
+The host part of the url including any port information.
+- eg. `http://localhost:3000`
+
+###### `options.restApiRoot`
+The api prefix used before resource information. Can be used in conjunction with
+`options.host` and `options.type` to build up the full url for a resource.
+- eg. `/api`
+
+###### `options.topLevelLinks`
+JSON API links object used at the top level of the JSON API response structure.
+- eg. `{links: {self: 'http://localhost:3000/api/posts'}}`
+
+###### `options.dataLinks`
+links object used to generate links for individual resource items. The structure is
+and object with JSON API link keys such as `self` or `related` that are defined as
+a function that will be called for each resource.
+
+Eg.
+```js
+options.dataLinks: {
+  self: function (resource) {
+    return 'http://localhost:3000/posts/' + resource.id;
+  }
+}
+```
+As shown above, each resource gets passed to the function and the result of the
+function is assigned to the key in the final JSON API response.
+
+###### `options.relationships`
+This contains all the relationship definitions for the model being serialized.
+Relationship definition objects are in the same format as in loopback's `Model.relations`
+definition. An object with relationship name keys, each having properties:
+
+- `modelTo` loopback model object
+- `keyTo` name of key on to model
+- `modelFrom` loopback model object
+- `keyFrom` name of key on from model
+- `type` type of relationship (belongsTo, hasOne, hasMany)
+
+This information is used to build relationship urls and even setup side loaded
+data correctly during the serialization process.
+
+eg.
+```js
+options.relationships = {
+  comments: { modelTo: ...etc },
+  tags: { modelTo: ...etc }
+}
+```
+
+###### `options.results`
+This is the actual data to be serialized. In `beforeJsonApiSerialize` and
+`jsonApiSerialize` this will be the raw data as you would ordinarily get it from
+loopback. In `afterJsonApiSerialize` this will be the serialized data ready for
+any final modifications.
+
+###### `options.exclude`
+This is the exclude settings as defined in the `exclude` configuration option
+explained earlier. Use this in `beforeJsonApiSerialize` to make any model specific
+adjustments before serialization.
+
+###### `options.attributes`
+This is the attributes settings as defined in the `attributes` configuration option
+explained earlier. Use this in `beforeJsonApiSerialize` to make any model specific
+adjustments before serialization.
 
 ## Serialization Hooks
 For occasions when you don't want to fully implement serialization for a model manually but
 you need to manipulate the serialization process, you can use the serialization
-hooks `beforeJsonApiSerialization` and `afterJsonApiSerialization`.
+hooks `beforeJsonApiSerialize` and `afterJsonApiSerialize`.
 
-### beforeJsonApiSerialization
+### beforeJsonApiSerialize
+In order to modify the serialization process on a model by model basis, you can
+define a `Model.beforeJsonApiSerialize` function as shown below. The function
+will be called with an options object and a callback which must be called with either
+an error as the first argument or the modified options object as the second
+parameter.
 
-#### example
+**Examples of things you might want to use this feature for**
+- modify the record(s) before serialization by modifying `options.results`
+- modify the resource type by modifying `options.type`
+- setup serialization differently depending on `options.method`
+- side load data (advanced)
+- modify the way relationships are serialized
+
+#### code example
 ```js
 module.exports = function (MyModel) {
   MyModel.beforeJsonApiSerialize = function (options, callback) {
     // either return an error
     var err = new Error('Unable to serialize record');
     err.status = 500;
-    cb(err)
+    callback(err)
 
     // or return modified records
-    if (Array.isArray(options.records)) {
+    if (Array.isArray(options.results)) {
       // modify an array of records
     } else {
       // modify a single record
     }
     // returned options.records will be serialized by either the default serialization process
     // or by a custom serialize function (described above) if one is present on the model.
-    cb(null, options);
+    callback(null, options);
   }
 }
 ```
 
 ##### function parameters
-- `options` All config options set for the serialization process
-- `callback` Callback to call with error or modified records
+- `options` All config options set for the serialization process. See the "function parameters"
+section above for info on what options properties are available for modification.
+- `callback` Callback to call with error or options object.
 
 #### example use case
 Because the `beforeJsonApiSerialize` method is passed all the options that will
 be used during serialization, it is possible to tweak options to affect the
-serialization process. One example of this is modifiying the `type` option to
+serialization process. One example of this is modifying the `type` option to
 change the resource type that will be output.
 
 ```js
@@ -311,7 +398,12 @@ module.exports = function (MyModel) {
 }
 ```
 
-### afterJsonApiSerialization
+### afterJsonApiSerialize
+In order to modify the serialized data on a model by model basis, you can
+define a `Model.afterJsonApiSerialize` function as shown below. The function
+will be called with an options object and a callback which must be called with either
+an error as the first argument or the modified options object as the second
+parameter.
 
 #### example
 ```js
@@ -320,16 +412,16 @@ module.exports = function (MyModel) {
     // either return an error
     var err = new Error('Unable to modify serialized record');
     err.status = 500;
-    cb(err)
+    callback(err)
 
     // or return modified records
-    if (Array.isArray(options.records)) {
+    if (Array.isArray(options.results)) {
       // modify an array of serialized records
     } else {
       // modify a single serialized record
     }
     // returned options.records will be output through the api.
-    cb(null, options);
+    callback(null, options);
   }
 }
 ```

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -84,6 +84,7 @@ module.exports = function (app, defaults) {
     }
     options = {
       model: model,
+      method: ctx.method.name,
       primaryKeyField: primaryKeyField,
       requestedIncludes: requestedIncludes,
       host: utils.hostFromContext(ctx),

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -20,7 +20,6 @@ module.exports = function (app, defaults) {
       modelNamePlural,
       relatedModelPlural,
       relations,
-      res,
       model,
       requestedIncludes;
 
@@ -84,6 +83,7 @@ module.exports = function (app, defaults) {
       requestedIncludes = ctx.req.remotingContext.args.filter.include;
     }
     options = {
+      model: model,
       primaryKeyField: primaryKeyField,
       requestedIncludes: requestedIncludes,
       host: utils.hostFromContext(ctx),
@@ -111,14 +111,11 @@ module.exports = function (app, defaults) {
     relations = utils.getRelationsFromContext(ctx, app);
 
     // Serialize our request
-    try {
-      res = serializer(type, data, relations, options);
-    } catch (e) {
-      next(e);
-    }
+    serializer(type, data, relations, options, function (err, results) {
+      if (err) return next(err);
 
-    ctx.result = res;
-
-    next();
+      ctx.result = results;
+      next();
+    });
   });
 };

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -2,10 +2,47 @@ var _ = require('lodash');
 var RelUtils = require('./utilities/relationship-utils');
 var utils = require('./utils');
 
-module.exports = function serializer (type, data, relations, options) {
+function defaultBeforeSerialize (options, cb) {
+  cb(null, options);
+}
 
+function defaultSerialize (options, cb) {
   var result = null;
   var resultData = {};
+
+  if (_.isArray(options.results)) {
+    result = parseCollection(options.type, options.results, options.relationships, options);
+  } else if (_.isPlainObject(options.results)) {
+    result = parseResource(options.type, options.results, options.relationships, options);
+  }
+
+  if (options.topLevelLinks) {
+    resultData.links = makeLinks(options.topLevelLinks);
+  }
+
+  resultData.data = result;
+
+  /**
+   * If we're requesting to sideload relationships...
+   */
+  if (options.requestedIncludes) {
+    try {
+      handleIncludes(resultData, options.requestedIncludes, options.relationships);
+    } catch (err) {
+      cb(err);
+    }
+  }
+
+  options.results = resultData;
+  cb(null, options);
+}
+
+function defaultAfterSerialize (options, cb) {
+  cb(null, options);
+}
+
+module.exports = function serializer (type, data, relations, options, cb) {
+  options = _.clone(options);
   options.attributes = options.attributes || {};
 
   options.isRelationshipRequest = false;
@@ -14,27 +51,33 @@ module.exports = function serializer (type, data, relations, options) {
     options.topLevelLinks.related = options.topLevelLinks.self.replace('/relationships/', '/');
     options.isRelationshipRequest = true;
   }
+  var serializeOptions;
+  var model = options.model;
 
-  if (_.isArray(data)) {
-    result = parseCollection(type, data, relations, options);
-  } else if (_.isPlainObject(data)) {
-    result = parseResource(type, data, relations, options);
-  }
+  var beforeSerialize = (typeof model.beforeJsonApiSerialize === 'function') ?
+    model.beforeJsonApiSerialize : defaultBeforeSerialize;
 
-  resultData.data = result;
+  var serialize = (typeof model.jsonApiSerialize === 'function') ?
+    model.jsonApiSerialize : defaultSerialize;
 
-  if (options.topLevelLinks) {
-    resultData.links = makeLinks(options.topLevelLinks);
-  }
+  var afterSerialize = (typeof model.afterJsonApiSerialize === 'function') ?
+    model.afterJsonApiSerialize : defaultAfterSerialize;
 
-  /**
-   * If we're requesting to sideload relationships...
-   */
-  if (options.requestedIncludes) {
-    handleIncludes(resultData, options.requestedIncludes, relations);
-  }
-
-  return resultData;
+  serializeOptions = _.defaults(options, {
+    type: type,
+    results: data,
+    relationships: relations
+  });
+  beforeSerialize(serializeOptions, function (err, serializeOptions) {
+    if (err) return cb(err);
+    serialize(serializeOptions, function (err, serializeOptions) {
+      if (err) return cb(err);
+      afterSerialize(serializeOptions, function (err, serializeOptions) {
+        if (err) return cb(err);
+        return cb(null, serializeOptions.results);
+      });
+    });
+  });
 };
 
 /**

--- a/test/override-serializer.test.js
+++ b/test/override-serializer.test.js
@@ -1,0 +1,124 @@
+var request = require('supertest');
+var loopback = require('loopback');
+var expect = require('chai').expect;
+var JSONAPIComponent = require('../');
+var app;
+var Post;
+var Comment;
+
+describe('hook in to modify serialization process', function () {
+  beforeEach(function (done) {
+    app = loopback();
+    app.set('legacyExplorer', false);
+    var ds = loopback.createDataSource('memory');
+
+    Post = ds.createModel('post', { title: String, content: String, other: String });
+    app.model(Post);
+
+    Comment = ds.createModel('comment', { title: String, comment: String, other: String });
+    app.model(Comment);
+
+    app.use(loopback.rest());
+
+    Post.create({title: 'my post', content: 'my post content', other: 'my post other'}, function () {
+      Comment.create({title: 'my comment title', comment: 'my comment', other: 'comment other'}, done);
+    });
+
+    JSONAPIComponent(app);
+  });
+
+  describe('before serialization', function () {
+    beforeEach(function () {
+      Post.beforeJsonApiSerialize = function (options, cb) {
+        options.type = 'notPosts';
+        cb(null, options);
+      };
+    });
+    afterEach(function () {
+      delete Post.beforeJsonApiSerialize;
+    });
+    it('should allow options to be modified before serialization', function (done) {
+      request(app).get('/posts')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body.data[0].type).to.equal('notPosts');
+          done();
+        });
+    });
+    it('should not affect models without a beforeJsonApiSerialize method', function (done) {
+      request(app).get('/comments')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body.data[0].type).to.equal('comments');
+          done();
+        });
+    });
+  });
+
+  describe('after serialization', function () {
+    beforeEach(function () {
+      Post.afterJsonApiSerialize = function (options, cb) {
+        options.results.data = options.results.data.map(function (result) {
+          result.attributes.testing = true;
+          return result;
+        });
+        cb(null, options);
+      };
+    });
+    afterEach(function () {
+      delete Post.afterJsonApiSerialize;
+    });
+    it('should allow results to be modified after serialization', function (done) {
+      request(app).get('/posts')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body.data[0].attributes.testing).to.equal(true);
+          done();
+        });
+    });
+    it('should not affect models without an afterJsonApiSerialize method', function (done) {
+      request(app).get('/comments')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body.data[0].attributes.testing).to.equal(undefined);
+          done();
+        });
+    });
+  });
+
+  describe('custom serialization', function () {
+    beforeEach(function () {
+      Post.jsonApiSerialize = function (options, cb) {
+        options.results = options.results.map(function (result) {
+          return result.title;
+        });
+        cb(null, options);
+      };
+    });
+    afterEach(function () {
+      delete Post.jsonApiSerialize;
+    });
+    it('should allow a custom serializer to be defined for a model', function (done) {
+      request(app).get('/posts')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body[0]).to.equal('my post');
+          done();
+        });
+    });
+    it('should not affect models without a jsonApiSerialize method', function (done) {
+      request(app).get('/comments')
+        .expect(200)
+        .end(function (err, res) {
+          expect(err).to.equal(null);
+          expect(res.body.data[0].attributes.title).to.equal('my comment title');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
@tsteuwer 
This PR makes it possible to hook in to adjust the serialization process.
You can hook in before and modify the options that will be used during serialization, you can hook in after serialization and modify the result or you can completely replace the serialization on a model by model basis.

I've tried to document how it works in the readme, let me know if you think its clear enough.