### PR TITLE
Restrict relationships call to updateAttributes

### DIFF
--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -14,6 +14,9 @@ module.exports = function (app, options) {
     if (utils.shouldNotApplyJsonApi(ctx, options)) {
       return next();
     };
+
+    if (ctx.method.name !== 'updateAttributes') return next();
+
     id = ctx.req.params.id;
     data = options.data;
     model = utils.getModelFromContext(ctx, app);


### PR DESCRIPTION
I believe what was happening was that in some
edge cases, GET requests were making it through
later relationship method checks.

Its more explicit and safe to just check what method
was called and restrict to the correct only