### PR TITLE
Serializer will return null when id is undefined

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -127,8 +127,7 @@ function parseResource (type, data, relations, options) {
     }
   });
 
-  // If there is no attributes found return
-  if (_.isEmpty(attributes)) {
+  if (_.isUndefined(resource.id)) {
     return null;
   }
 

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -15,14 +15,14 @@ describe('include option', function () {
     Post = ds.createModel('post', { title: String });
     app.model(Post);
     Post.customMethod = function (cb) {
-      cb(null, {prop: 'value'});
+      cb(null, {prop: 'value', id: null});
     };
     Post.remoteMethod('customMethod', {
       http: {verb: 'get', path: '/custom'},
       returns: {root: true}
     });
     Post.customMethod2 = function (cb) {
-      cb(null, {prop: 'value'});
+      cb(null, {prop: 'value', id: null});
     };
     Post.remoteMethod('customMethod2', {
       http: {verb: 'get', path: '/custom2'},
@@ -32,7 +32,7 @@ describe('include option', function () {
     Comment = ds.createModel('comment', { comment: String });
     app.model(Comment);
     Comment.customMethod = function (cb) {
-      cb(null, {prop: 'value'});
+      cb(null, {prop: 'value', id: null});
     };
     Comment.remoteMethod('customMethod', {
       http: {verb: 'get', path: '/custom'},
@@ -60,7 +60,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body.data).to.have.keys('type', 'attributes', 'links');
+          expect(res.body.data).to.have.keys('id', 'type', 'attributes', 'links');
           done();
         });
     });
@@ -70,7 +70,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body.data).to.have.keys('type', 'attributes', 'links');
+          expect(res.body.data).to.have.keys('id', 'type', 'attributes', 'links');
           done();
         });
     });
@@ -90,7 +90,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body.data).to.have.keys('type', 'attributes', 'links');
+          expect(res.body.data).to.have.keys('id', 'type', 'attributes', 'links');
           done();
         });
     });
@@ -100,7 +100,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body).to.deep.equal({ prop: 'value'});
+          expect(res.body).to.deep.equal({ prop: 'value', id: null });
           done();
         });
     });
@@ -120,7 +120,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body.data).to.have.keys('type', 'attributes', 'links');
+          expect(res.body.data).to.have.keys('id', 'type', 'attributes', 'links');
           done();
         });
     });
@@ -130,7 +130,7 @@ describe('include option', function () {
         .expect(200)
         .end(function (err, res) {
           expect(err).to.equal(null);
-          expect(res.body.data).to.have.keys('type', 'attributes', 'links');
+          expect(res.body.data).to.have.keys('id', 'type', 'attributes', 'links');
           done();
         });
     });

--- a/test/throughModel.test.js
+++ b/test/throughModel.test.js
@@ -4,27 +4,27 @@ var expect = require('chai').expect;
 var JSONAPIComponent = require('../');
 var app, User, Interest, Topic;
 
-describe('through Model', function(){
-  
+describe('through Model', function () {
+
   beforeEach(function () {
     app = loopback();
     app.set('legacyExplorer', false);
-    ds = loopback.createDataSource('memory');
+    var ds = loopback.createDataSource('memory');
 
     User = ds.createModel('user', {
       id: {type: Number, id: true},
       name: String
     });
-    
+
     app.model(User);
-    
+
     Topic = ds.createModel('topic', {
       id: {type: Number, id: true},
       name: String
     });
 
     app.model(Topic);
-    
+
     Interest = ds.createModel('interest', {
       id: {type: Number, id: true}
     });
@@ -33,43 +33,44 @@ describe('through Model', function(){
 
     User.hasMany(Topic, { through: Interest });
     Topic.hasMany(User, { through: Interest });
-    
+
     Interest.belongsTo(User);
     Interest.belongsTo(Topic);
-        
+
     app.use(loopback.rest());
     JSONAPIComponent(app, {restApiRoot: '/'});
   });
 
-  it('should allow interest to be created', function(done){
-    
-    User.create({ name: 'User 1' }, function(err, user){
+  it('should allow interest to be created', function (done) {
+
+    User.create({ name: 'User 1' }, function (err, user) {
       expect(err).to.equal(null);
-      
-      Topic.create({ name: 'Topic 1'}, function(err, topic){
+
+      Topic.create({ name: 'Topic 1'}, function (err, topic) {
         expect(err).to.equal(null);
-        
+
         request(app)
           .post('/interests')
           .send({
             data: {
               type: 'interests',
+              attributes: {},
               relationships: {
-                user: { id: user.id, type: 'users' },
-                topic: { id: topic.id, type: 'topics' }
+                user: { data: { id: user.id, type: 'users' } },
+                topic: { data: { id: topic.id, type: 'topics' } }
               }
             }
           })
-          .end(function(err, res){
+          .end(function (err, res) {
             expect(err).to.equal(null);
             console.error(res.body.errors);
             expect(res).to.not.have.deep.property('body.errors');
-            expect(res).to.have.deep.property('body.data.id').and.equal("1");
+            expect(res).to.have.deep.property('body.data.id').and.equal('1');
             done(err);
           });
       });
     });
-    
+
   });
-  
+
 });


### PR DESCRIPTION
Serializer used to return null when there were no attributes.
This caused problems for creating models that only had relationships.

I changed the serializer to return null when id is undefined.
This broke include tests because they expected customMethod to
be able to return attributes without an id.

JSONAPI requires an id to be present in a resource document,
but the id can be null.

*Note*: This commit changes expectation of customMethod to return an id, which can be null.