### PR TITLE
Move belongsTo relationship handling

### DIFF
--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -41,8 +41,39 @@ module.exports = function deserializer (options, cb) {
       if (err) return cb(err);
       afterDeserialize(deserializeOptions, function (err, deserializeOptions) {
         if (err) return cb(err);
+
+        belongsToRelationships(deserializeOptions);
         return cb(null, deserializeOptions);
       });
     });
   });
 };
+
+function belongsToRelationships (options) {
+  var data = options.data;
+  var model = options.model;
+
+  if (!data || !data.data || !model || !data.data.relationships) {
+    return;
+  }
+
+  _.each(data.data.relationships, function (relationship, name) {
+    var serverRelation = model.relations[name];
+    if (!serverRelation) return;
+    var type = serverRelation.type;
+
+    // only handle belongsTo
+    if (type !== 'belongsTo') return;
+
+    var fkName = serverRelation.keyFrom;
+    var modelTo = serverRelation.modelFrom;
+
+    if (!modelTo) return false;
+
+    if (!relationship.data) {
+      options.result[fkName] = null;
+    } else {
+      options.result[fkName] = relationship.data.id;
+    }
+  });
+}

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -15,11 +15,12 @@ module.exports = function (app, options) {
       return next();
     };
 
-    if (ctx.method.name !== 'updateAttributes') return next();
+    if (!ctx.method.name === 'updateAttributes') return next();
 
     id = ctx.req.params.id;
     data = options.data;
     model = utils.getModelFromContext(ctx, app);
+
     relationships(id, data, model);
 
     next();
@@ -56,6 +57,10 @@ function relationships (id, data, model) {
     var serverRelation = model.relations[name];
     if (!serverRelation) return;
     var type = serverRelation.type;
+
+    // don't handle belongsTo in relationships function
+    if (type === 'belongsTo') return;
+
     var modelTo = serverRelation.modelTo;
 
     var fkName = serverRelation.keyTo;


### PR DESCRIPTION
Change from doing a saveAttributes in order to save the fk to model, 
to instead just setting fk on model and letting the natural save process commit the change.

The main advantage of doing this is to prevent double
operation hooks firing (and no unnecessary db writes)