### PR TITLE
Change to support host being passed in as an option and meta data in jsonapi response

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Example:
 {
   "loopback-component-jsonapi": {
     "restApiRoot": "/api",
+    "host": "https://www.mydomain.com",
     "enable": true,
     "handleErrors": true,
     "exclude": [
@@ -99,6 +100,22 @@ Url prefix to be used in conjunction with host and resource paths. eg. http://12
 
 - Type: `string`
 - Default: `/api`
+
+### host
+The url of the application, to be used when constructing links to relationships.  Useful where the service is proxied and the application believes
+it is running on a different url to that seen by the consuming service.
+
+#### example
+```js
+{
+  ...
+  "host": "https://www.mydomain.com",
+  ...
+}
+```
+
+- Type: `string`
+- Default: `null`
 
 ### enable
 Whether the component should be enabled or disabled. Defaults to `true`, flip it to `false` if you need to turn the component off without removing the configuration for some reason.

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -116,6 +116,7 @@ module.exports = function (app, defaults) {
       app: app,
       model: model,
       method: ctx.method.name,
+      meta: ctx.meta ? utils.clone(ctx.meta) : null,
       primaryKeyField: primaryKeyField,
       requestedIncludes: requestedIncludes,
       host: defaults.host || utils.hostFromContext(ctx),

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -2,6 +2,7 @@
 var serializer = require('./serializer');
 var utils = require('./utils');
 var _ = require('lodash');
+var url = require('url');
 var regexs = [
   /^find$/,
   /^create$/,
@@ -117,13 +118,11 @@ module.exports = function (app, defaults) {
       method: ctx.method.name,
       primaryKeyField: primaryKeyField,
       requestedIncludes: requestedIncludes,
-      host: utils.hostFromContext(ctx),
-      topLevelLinks: {
-        self: utils.urlFromContext(ctx)
-      },
+      host: defaults.host || utils.hostFromContext(ctx),
       dataLinks: {
         self: function (item) {
-          var args = [ctx.req.protocol, ctx.req.get('host'), options.restApiRoot];
+          var urlComponents = url.parse(options.host);
+          var args = [urlComponents.protocol.replace(':', ''), urlComponents.host, options.restApiRoot];
 
           if (relatedModelPlural) {
             args.push(relatedModelPlural);
@@ -136,6 +135,9 @@ module.exports = function (app, defaults) {
           return utils.buildModelUrl.apply(this, args);
         }
       }
+    };
+    options.topLevelLinks = {
+      self: options.host + ctx.req.originalUrl
     };
 
     options = _.defaults(options, defaults);

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -21,6 +21,7 @@ function defaultSerialize (options, cb) {
   }
 
   resultData.data = result;
+  if (options.meta) resultData.meta = options.meta;
 
   /**
    * If we're requesting to sideload relationships...

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "http-status-codes": "^1.0.5",
     "inflection": "^1.7.2",
     "lodash": "^4.0.0",
-    "type-is": "^1.6.9",
-    "url": "^0.11.0"
+    "type-is": "^1.6.9"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "http-status-codes": "^1.0.5",
     "inflection": "^1.7.2",
     "lodash": "^4.0.0",
-    "type-is": "^1.6.9"
+    "type-is": "^1.6.9",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
**This PR is opened primarily for comment.**

There are two distinct changes here
1) We wanted the ability to send in a host different to that calculated from context.  For example, if you're running Cloudflare to provide https and the app itself is running over http.
I'm not sure the current classification as the options being labelled as 'defaults' is the correct approach.  If any user supplied values come into the function as 'defaults' clash with those provided in the options object, then they will be discarded.

2) Second change is to allow users the ability to add custom data into the jsonapi `meta` tag.  Useful for features like 'total-pages' while supporting pagination.
