### PR TITLE
fix relationships urls should respect options.type

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -188,7 +188,6 @@ function parseRelations (data, relations, options) {
     var pk = data[options.primaryKeyField];
     var fk = data[fkName];
 
-    var fromType = utils.pluralForModel(relation.modelFrom);
     var toType = '';
     if (relation.polymorphic && utils.relationFkOnModelFrom(relation)) {
       var discriminator = relation.polymorphic.discriminator;
@@ -204,7 +203,7 @@ function parseRelations (data, relations, options) {
 
       relationships[name] = {
         links: {
-          related: options.host + options.restApiRoot + '/' + fromType + '/' + pk + '/' + name
+          related: options.host + options.restApiRoot + '/' + options.type + '/' + pk + '/' + name
         }
       };
     }


### PR DESCRIPTION
@digitalsadhu I think this behaviour is more correct... fixes the type/self of a resource not matching the relationship urls. Any complications this will cause?