### PR TITLE
fix(http status codes): Remove status code generalisation

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -47,9 +47,6 @@ function JSONAPIErrorHandler (err, req, res, next) {
       )
     })
   } else if (err.message) {
-    debug('Handling error generally. Eg. 404, 500.')
-    // this block is for handling other non validation related errors. 404s, 500s etc.
-
     // convert specific errors below to validation errors.
     // These errors are from checks on the incoming payload to ensure it is
     // JSON API compliant. If we switch to being able to use the Accept header
@@ -83,35 +80,11 @@ function JSONAPIErrorHandler (err, req, res, next) {
     errors.push(buildErrorResponse(statusCodes.INTERNAL_SERVER_ERROR, 'Internal Server error', 'GENERAL_SERVER_ERROR'))
   }
 
-  // generalise the error code. More specific error codes are kept
-  // with each error object
-  debug('Generalising error status code. Eg. 404 -> 400 for the response')
-  statusCode = generalizeStatusCode(statusCode)
-
   // send the errors and close out the response.
   debug('Sending error response')
   debug('Response Code:', statusCode)
   debug('Response Object:', {errors: errors})
   res.status(statusCode).send({errors: errors}).end()
-}
-
-/**
- * Takes a more specific error code and generalises it to 400 or 500.
- * If a generalisation cannot occur, the original code will be returned.
- * @private
- * @memberOf {Errors}
- * @param {number} statusCode
- * @return {number}
- */
-function generalizeStatusCode (statusCode) {
-  switch (String(statusCode)[0]) {
-    case '4':
-      return statusCodes.BAD_REQUEST
-    case '5':
-      return statusCodes.INTERNAL_SERVER_ERROR
-  }
-
-  return statusCode
 }
 
 /**

--- a/test/belongsTo.test.js
+++ b/test/belongsTo.test.js
@@ -434,29 +434,31 @@ describe('loopback json api belongsTo relationships', function () {
     beforeEach(function (done) {
       request(app).post('/posts/')
         .send({
-          'data': {
-            'type': 'posts',
-            'attributes': { 'title': 'Post 1', 'content': 'This is my first post'}
-        }})
+          data: {
+            type: 'posts',
+            attributes: { title: 'Post 1', content: 'This is my first post' }
+          }
+        })
         .set('Accept', 'application/vnd.api+json')
         .set('Content-Type', 'application/json')
         .end(function (err) {
           expect(err).to.equal(null)
           request(app).post('/posts')
             .send({
-              'data': {
-                'type': 'posts',
-                'attributes': {'title': 'Post 2', 'content': 'This is my second post'}
-            }})
+              data: {
+                type: 'posts',
+                attributes: {title: 'Post 2', content: 'This is my second post'}
+              }
+            })
             .set('Accept', 'application/vnd.api+json')
             .set('Content-Type', 'application/json')
             .end(function (err) {
               expect(err).to.equal(null)
               request(app).post('/comments')
                 .send({'data': {
-                    'type': 'comments',
-                    'attributes': {'title': 'First comment', 'comment': 'Comment 1 text'},
-                    'relationships': {'post': {'data': {'type': 'posts', 'id': '1'}}}
+                  'type': 'comments',
+                  'attributes': {'title': 'First comment', 'comment': 'Comment 1 text'},
+                  'relationships': {'post': {'data': {'type': 'posts', 'id': '1'}}}
                 }})
                 .set('Accept', 'application/vnd.api+json')
                 .set('Content-Type', 'application/json')
@@ -464,9 +466,9 @@ describe('loopback json api belongsTo relationships', function () {
                   expect(err).to.equal(null)
                   request(app).post('/comments')
                     .send({'data': {
-                        'type': 'comments:',
-                        'attributes': {'title': 'Second comment', 'comment': 'Comment 2 text'},
-                        'relationships': {'post': {'data': {'type': ' posts', 'id': '2'}}}
+                      'type': 'comments:',
+                      'attributes': {'title': 'Second comment', 'comment': 'Comment 2 text'},
+                      'relationships': {'post': {'data': {'type': ' posts', 'id': '2'}}}
                     }})
                     .set('Accept', 'application/vnd.api+json')
                     .set('Content-Type', 'application/json')

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -59,8 +59,7 @@ describe('Dont override config.js ', function () {
       })
       .set('Accept', 'application/vnd.api+json')
       .set('Content-Type', 'application/json')
-      .expect(400)
+      .expect(413)
       .end(done)
   })
-
 })

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -60,13 +60,13 @@ describe('loopback json api errors', function () {
   })
 
   describe('status codes', function () {
-    it('GET /models/100 should return a generalized 400 not found error', function (done) {
+    it('GET /models/100 should return a 404 not found error', function (done) {
       request(app).get('/posts/100')
-        .expect(400)
+        .expect(404)
         .end(done)
     })
 
-    it('GET /models/100 should return a generalized 400 not found error', function (done) {
+    it('GET /models/100 should return a 404 not found error', function (done) {
       request(app).get('/posts/100')
         .end(function (err, res) {
           expect(err).to.equal(null)
@@ -83,17 +83,17 @@ describe('loopback json api errors', function () {
         })
     })
 
-    it('POST /models should return a general 400 status code if type key is not present', function (done) {
+    it('POST /models should return a 422 status code if type key is not present', function (done) {
       request(app).post('/posts')
-        .send({ data: { attributes: { title: 'my post', content: 'my post content' }}})
-        .expect(400)
+        .send({ data: { attributes: { title: 'my post', content: 'my post content' } } })
+        .expect(422)
         .set('Content-Type', 'application/json')
         .end(done)
     })
 
     it('POST /models should return a more specific 422 status code on the error object if type key is not present', function (done) {
       request(app).post('/posts')
-        .send({ data: { attributes: { title: 'my post', content: 'my post content' }}})
+        .send({ data: { attributes: { title: 'my post', content: 'my post content' } } })
         .set('Content-Type', 'application/json')
         .end(function (err, res) {
           expect(err).to.equal(null)
@@ -110,12 +110,12 @@ describe('loopback json api errors', function () {
         })
     })
 
-    it('POST /models should return an 400 error if model title is not present', function (done) {
+    it('POST /models should return an 422 error if model title is not present', function (done) {
       Post.validatesPresenceOf('title')
 
       request(app).post('/posts')
         .send({ data: { type: 'posts' } })
-        .expect(400)
+        .expect(422)
         .set('Content-Type', 'application/json')
         .end(done)
     })

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -30,7 +30,7 @@ describe('loopback json api component find methods', function () {
 
     it('GET /models/:id should have the JSON API Content-Type header set on individual resource responses', function (done) {
       request(app).get('/posts/1')
-        .expect(400)
+        .expect(404)
         .expect('Content-Type', 'application/vnd.api+json; charset=utf-8')
         .end(done)
     })
@@ -156,9 +156,9 @@ describe('loopback json api component find methods', function () {
         })
     })
 
-    it('GET model/:id should return a general 400 when there are no results', function (done) {
+    it('GET model/:id should return a general 404 when there are no results', function (done) {
       request(app).get('/posts/1')
-        .expect(400)
+        .expect(404)
         .end(done)
     })
   })
@@ -207,9 +207,9 @@ describe('loopback json api component find methods', function () {
   })
 
   describe('Errors', function () {
-    it('GET /models/doesnt/exist should return a general 400 error', function (done) {
+    it('GET /models/doesnt/exist should return a general 404 error', function (done) {
       request(app).get('/posts/doesnt/exist')
-        .expect(400)
+        .expect(404)
         .end(done)
     })
   })

--- a/test/hasMany.test.js
+++ b/test/hasMany.test.js
@@ -312,7 +312,6 @@ describe('loopback json api hasMany relationships', function () {
           .end(done)
       })
     })
-
   })
 
   describe('Nested relationships', function () {

--- a/test/hasOne.test.js
+++ b/test/hasOne.test.js
@@ -283,6 +283,5 @@ describe('loopback json api hasOne relationships', function () {
           .end(done)
       })
     })
-
   })
 })

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -70,7 +70,7 @@ describe('loopback json api component update method', function () {
         .end(done)
     })
 
-    it('PATCH /models/:id should return 400 when attempting to edit non existing resource', function (done) {
+    it('PATCH /models/:id should return 404 when attempting to edit non existing resource', function (done) {
       request(app).patch('/posts/10')
         .send({
           data: {
@@ -82,7 +82,7 @@ describe('loopback json api component update method', function () {
             }
           }
         })
-        .expect(400)
+        .expect(404)
         .end(done)
     })
   })
@@ -211,7 +211,7 @@ describe('loopback json api component update method', function () {
         })
     })
 
-    it('PATCH /models/:id should return an 400 error if `type` key is not present and include an errors array', function (done) {
+    it('PATCH /models/:id should return an 422 error if `type` key is not present and include an errors array', function (done) {
       request(app).patch('/posts/1')
         .send({
           data: {
@@ -222,7 +222,7 @@ describe('loopback json api component update method', function () {
             }
           }
         })
-        .expect(400)
+        .expect(422)
         .set('Content-Type', 'application/json')
         .end(function (err, res) {
           expect(err).to.equal(null)
@@ -236,7 +236,7 @@ describe('loopback json api component update method', function () {
         })
     })
 
-    it('PATCH /models/:id should return an 400 error if `id` key is not present and include an errors array', function (done) {
+    it('PATCH /models/:id should return an 422 error if `id` key is not present and include an errors array', function (done) {
       request(app).patch('/posts/1')
         .send({
           data: {
@@ -247,7 +247,7 @@ describe('loopback json api component update method', function () {
             }
           }
         })
-        .expect(400)
+        .expect(422)
         .set('Content-Type', 'application/json')
         .end(function (err, res) {
           expect(err).to.equal(null)


### PR DESCRIPTION
Initial intention to generalise status codes at the top level (404 -> 400) was misguided. Removed by
this commit

Breaks exisiting clients expectation of http status codes. Fixes #112.