### PR TITLE
chore(package): remove jsinspect

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "description": "JSONAPI support for loopback",
   "main": "lib/index.js",
   "scripts": {
-    "inspect": "jsinspect .",
-    "test": "npm run lint && istanbul cover _mocha --report lcovonly --reporter=spec ./test/**/*.test.js && npm run inspect && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test": "npm run lint && istanbul cover _mocha --report lcovonly --reporter=spec ./test/**/*.test.js && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "tester": "mocha --reporter=spec ./test/**/*.test.js",
     "coverage": "istanbul cover _mocha ./test/**/*.test.js",
     "lint": "standard .",
@@ -42,7 +41,6 @@
     "chai": "^3.3.0",
     "coveralls": "^2.11.9",
     "istanbul": "^0.4.5",
-    "jsinspect": "^0.8.0",
     "loopback": "^2.32.0",
     "loopback-datasource-juggler": "^2.50.0",
     "mocha": "^3.0.2",


### PR DESCRIPTION
jsinspect was added arbitrarily at some point. I don't want it failing the build