### PR TITLE
feat(serialize): Use HTTP path when building model relation links

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -18,10 +18,13 @@ module.exports = function (app, defaults) {
   app.remotes().after('**', function (ctx, next) {
     var data,
       type,
+      path,
       options,
       modelNamePlural,
+      modelPath,
       relatedModel,
       relatedModelPlural,
+      relatedModelPath,
       relations,
       model,
       requestedIncludes
@@ -56,7 +59,9 @@ module.exports = function (app, defaults) {
     data = utils.clone(ctx.result)
     model = utils.getModelFromContext(ctx, app)
     modelNamePlural = utils.pluralForModel(model)
+    modelPath = utils.httpPathForModel(model)
     type = modelNamePlural
+    path = modelPath
     relations = utils.getRelationsFromContext(ctx, app)
 
     /**
@@ -83,11 +88,13 @@ module.exports = function (app, defaults) {
         relatedModel = relation.modelTo
       }
       relatedModelPlural = utils.pluralForModel(relatedModel)
+      relatedModelPath = utils.httpPathForModel(relatedModel)
       primaryKeyField = utils.primaryKeyForModel(relatedModel)
 
       if (relatedModelPlural) {
         type = relatedModelPlural
         model = relatedModel
+        path = relatedModelPath
         relations = model.relations
       }
     }
@@ -118,6 +125,7 @@ module.exports = function (app, defaults) {
     options = {
       app: app,
       model: model,
+      modelPath: path,
       method: ctx.method.name,
       meta: ctx.meta ? utils.clone(ctx.meta) : null,
       primaryKeyField: primaryKeyField,
@@ -126,15 +134,13 @@ module.exports = function (app, defaults) {
       dataLinks: {
         self: function (item) {
           var urlComponents = url.parse(options.host)
-          var args = [urlComponents.protocol.replace(':', ''), urlComponents.host, options.restApiRoot]
-
-          if (relatedModelPlural) {
-            args.push(relatedModelPlural)
-          } else {
-            args.push(modelNamePlural)
-          }
-
-          args.push(item.id)
+          var args = [
+            urlComponents.protocol.replace(':', ''),
+            urlComponents.host,
+            options.restApiRoot,
+            path,
+            item.id
+          ]
 
           return utils.buildModelUrl.apply(this, args)
         }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -216,7 +216,7 @@ function parseRelations (data, relations, options) {
     if (!options.isRelationshipRequest) {
       relationships[name] = {
         links: {
-          related: options.host + options.restApiRoot + '/' + options.type + '/' + pk + '/' + name
+          related: options.host + options.restApiRoot + '/' + options.modelPath + '/' + pk + '/' + name
         }
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,7 @@ module.exports = {
   hostFromContext: hostFromContext,
   modelNameFromContext: modelNameFromContext,
   pluralForModel: pluralForModel,
+  httpPathForModel: httpPathForModel,
   urlFromContext: urlFromContext,
   primaryKeyForModel: primaryKeyForModel,
   shouldNotApplyJsonApi: shouldNotApplyJsonApi,
@@ -36,10 +37,6 @@ function pluralForModel (model) {
     return model.pluralModelName
   }
 
-  if (model.settings && model.settings.http && model.settings.http.path) {
-    return model.settings.http.path
-  }
-
   if (model.settings && model.settings.plural) {
     return model.settings.plural
   }
@@ -49,6 +46,20 @@ function pluralForModel (model) {
   }
 
   return inflection.pluralize(model.sharedClass.name)
+}
+
+/**
+ * Returns the plural path for a model
+ * @public
+ * @memberOf {Utils}
+ * @param {Object} model
+ * @return {String}
+ */
+function httpPathForModel (model) {
+  if (model.settings && model.settings.http && model.settings.http.path) {
+    return model.settings.http.path
+  }
+  return pluralForModel(model);
 }
 
 /**


### PR DESCRIPTION
If a path is defined. Otherwise use the plural name, as before