### PR TITLE
feat(config): Use disableRemoteMethodByName instead of disableRemoteMethod

### DIFF
--- a/lib/removeRemoteMethods.js
+++ b/lib/removeRemoteMethods.js
@@ -3,13 +3,16 @@ module.exports = function (app, options) {
 
   // use loopbacks standard API to disable all methods that JSON API
   // does not support.
-  var isStatic = true
 
   if (options.hideIrrelevantMethods !== false) {
     options.debug('Disable methods not supported by `jsonapi`. (Set `options.hideIrrelevantMethods = false` to re-enable)')
     Object.keys(models).forEach(function (model) {
       ['upsert', 'exists', 'findOne', 'count', 'createChangeStream', 'updateAll'].forEach(function (method) {
-        models[model].disableRemoteMethod(method, isStatic)
+        if (models[model].disableRemoteMethodByName) {
+          models[model].disableRemoteMethodByName(method)
+        } else if (models[model].disableRemoteMethod) {
+          models[model].disableRemoteMethod(method, true)
+        }
       })
     })
     options.debug('`upsert`, `exists`, `findOne`, `count`, `createChangeStream` and `updateAll` disabled for all models')


### PR DESCRIPTION
The latter is deprecated

http://apidocs.strongloop.com/loopback/#model-disableremotemethod
http://apidocs.strongloop.com/loopback/#model-disableremotemethodbyname