### PR TITLE
proper id check

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -283,7 +283,7 @@ function parseRelations (data, relations, options) {
  * @return {Object|null}
  */
 function makeRelation (type, id, options) {
-  if (_.isEmpty(id)) {
+  if (!_.includes(['string', 'number'], typeof id) || !id) {
     return null
   }
 


### PR DESCRIPTION
We are using postgress and integer ids for models. Lodash isEmpty method is used incorrectly in this case `Checks if value is an empty object, collection, map, or set.`
https://lodash.com/docs/4.17.4#isEmpty

Here is fix which support integer ids.