### PR TITLE
parse include filter 

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -102,7 +102,7 @@ module.exports = function (app, defaults) {
 
     // If we're sideloading, we need to add the includes
     if (ctx.req.isSideloadingRelationships) {
-      requestedIncludes = ctx.req.remotingContext.args.filter.include
+      requestedIncludes = utils.setRequestedIncludes(ctx.req.remotingContext.args.filter.include)
     }
 
     if (model.definition.settings.scope) {
@@ -119,7 +119,7 @@ module.exports = function (app, defaults) {
       if (typeof include === 'string') {
         requestedIncludes.push(include)
       } else if (_.isArray(include)) {
-        requestedIncludes = requestedIncludes.concat(include)
+        requestedIncludes = requestedIncludes.concat(utils.setRequestedIncludes(include))
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ module.exports = {
   shouldNotApplyJsonApi: shouldNotApplyJsonApi,
   shouldApplyJsonApi: shouldApplyJsonApi,
   relationFkOnModelFrom: relationFkOnModelFrom,
+  setRequestedIncludes: setRequestedIncludes,
   setIncludedRelations: setIncludedRelations
 }
 
@@ -237,4 +238,22 @@ function setIncludedRelations (relations, app) {
     }
   }
   return relations
+}
+
+function setRequestedIncludes (include) {
+  if (!include) return undefined
+
+  if (typeof include === 'string') {
+    return include
+  }
+
+  return include.map(function (inc) {
+    if (typeof inc === 'string') {
+      return inc
+    }
+
+    if (inc instanceof Object) {
+      return inc.relation
+    }
+  })
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,14 +246,16 @@ function setRequestedIncludes (include) {
   if (typeof include === 'string') {
     return include
   }
+  if (include instanceof Array) {
+    return include.map(function (inc) {
+      if (typeof inc === 'string') {
+        return inc
+      }
 
-  return include.map(function (inc) {
-    if (typeof inc === 'string') {
-      return inc
-    }
-
-    if (inc instanceof Object) {
-      return inc.relation
-    }
-  })
+      if (inc instanceof Object) {
+        return inc.relation
+      }
+    })
+  }
+  return include
 }

--- a/test/scopeInclude.test.js
+++ b/test/scopeInclude.test.js
@@ -127,6 +127,28 @@ describe('include option', function () {
             done()
           })
       })
+      it('should include comments', function (done) {
+        request(app)
+          .get('/posts/1?filter={"include":["comments"]}')
+          .end(function (err, res) {
+            expect(err).to.equal(null)
+            expect(res.body.included.length).equal(2)
+            expect(res.body.included[0].type).equal('comments')
+            expect(res.body.included[1].type).equal('comments')
+            done()
+          })
+      })
+      it('should include categories with empty attributes object', function (done) {
+        request(app)
+          .get('/posts/1?filter={"include":[{"relation":"category", "scope": {"fields": ["id"]}}]}')
+          .end(function (err, res) {
+            expect(err).to.equal(null)
+            expect(res.body.included.length).equal(3)
+            expect(res.body.included[0].type).equal('categories')
+            expect(res.body.included[0].attributes).to.include({})
+            done()
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
For now we can't use full include functionality because component can parse just array of strings.
But I need to include relation with scope
E.g.
```
include= [{"relation": "user", "scope": {"fields": ["name"]}}]
```

I've added function which sets requestedIncludes data