### PR TITLE
null response for empty BelongsTo relationship

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -269,6 +269,8 @@ function parseRelations (data, relations, options) {
     // No `data` key should be present unless there is actual relationship data.
     if (relationship) {
       relationships[name].data = relationship
+    } else if (relation.type === 'belongsTo') {
+      relationships[name].data = null
     }
   })
 


### PR DESCRIPTION
BelongsTo relationship model id locates in the same model. We definitely know that values is null