### PR TITLE
feat(error debug) #125 - Return a `source.stack` key on response when error

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,9 @@ out of the box with EmberJS.
 
 ### errorStackInResponse
 Along handleErrors, When true, this option will send the error stack if available within the error
-reponse. It will be stored under the `source.stack` key.
+response. It will be stored under the `source.stack` key.
 
-**Be careful, this option should never be enabled in production environment. It can propagate some
-sensitive datas.**
+**Please be careful, this option should never be enabled in a production environment. Doing so can expose sensitive data.**
 
 #### example
 ```js
@@ -440,9 +439,9 @@ module.exports = function (MyModel) {
 ```
 
 ## Custom Errors
-Generic errors respond with a 500, but sometime you want to have a better control over the error that is returned to the client, taking advantages of fields provided by JSONApi.
+Generic errors respond with a 500, but sometimes you want to have a better control over the error that is returned to the client, taking advantages of fields provided by JSONApi.
 
-**It is recommanded to extend the base Error constructor, before throwing errors, ex: BadRequestError**
+**It is recommended that you extend the base Error constructor before throwing errors. Eg. BadRequestError**
 
 `meta` and `source` fields needs to be objects.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Example:
     "host": "https://www.mydomain.com",
     "enable": true,
     "handleErrors": true,
+    "errorStackInResponse": false,
     "exclude": [
       {"model": "comment"},
       {"methods": "find"},
@@ -200,6 +201,25 @@ out of the box with EmberJS.
 
 - Type: `boolean`
 - Default: `true`
+
+### errorStackInResponse
+Along handleErrors, When true, this option will send the error stack if available within the error
+reponse. It will be stored under the `source.stack` key.
+
+**Be careful, this option should never be enabled in production environment. It can propagate some
+sensitive datas.**
+
+#### example
+```js
+{
+  ...
+  "errorStackInResponse": NODE_ENV === 'development',
+  ...
+}
+```
+
+- Type: `boolean`
+- Default: `false`
 
 ### exclude
 Allows blacklisting of models and methods.

--- a/README.md
+++ b/README.md
@@ -439,6 +439,45 @@ module.exports = function (MyModel) {
 }
 ```
 
+## Custom Errors
+Generic errors respond with a 500, but sometime you want to have a better control over the error that is returned to the client, taking advantages of fields provided by JSONApi.
+
+**It is recommanded to extend the base Error constructor, before throwing errors, ex: BadRequestError**
+
+`meta` and `source` fields needs to be objects.
+
+#### example
+```js
+module.exports = function (MyModel) {
+  MyModel.find = function () {
+    var err = new Error('April 1st, 1998');
+    
+    err.status = 418;
+    err.name = 'I\'m a teapot';
+    err.source = { model: 'Post', method: 'find' };
+    err.detail = 'April 1st, 1998';
+    err.code = 'i\'m a teapot';
+    err.meta = { rfc: 'RFC2324' };
+
+    throw err
+  }
+}
+
+// This will be returned as :
+// {
+//   errors: [
+//     {
+//       status: 418,
+//       meta: { rfc: 'RFC2324' },
+//       code: 'i\'m a teapot',
+//       detail: 'April 1st, 1998',
+//       title: 'I\'m a teapot',
+//       source: { model: 'Post', method: 'find' }
+//     }
+//   ]
+// }
+```
+
 ##### function parameters
 
 - `options` All config options set for the deserialization process.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,10 +1,12 @@
 'use strict'
 
 var debug
+var errorStackInResponse
 var statusCodes = require('http-status-codes')
 
 module.exports = function (app, options) {
   debug = options.debug
+  errorStackInResponse = options.errorStackInResponse
 
   if (options.handleErrors !== false) {
     debug(
@@ -80,7 +82,7 @@ function JSONAPIErrorHandler (err, req, res, next) {
     }
 
     errors.push(
-      buildErrorResponse(statusCode, err.message, err.code, err.name)
+      buildErrorResponse(statusCode, err.message, err.code, err.name, null, err.stack)
     )
   } else {
     debug(
@@ -112,6 +114,7 @@ function JSONAPIErrorHandler (err, req, res, next) {
  * @param {String} errorCode internal system error code
  * @param {String} errorName error title for the user, human readable
  * @param {String} propertyName for validation errors, name of property validation refers to
+ * @param {String} errorStack Some debbuging informations
  * @return {Object}
  */
 function buildErrorResponse (
@@ -119,13 +122,20 @@ function buildErrorResponse (
   errorDetail,
   errorCode,
   errorName,
-  propertyName
+  propertyName,
+  errorStack
 ) {
-  return {
+  var out = {
     status: httpStatusCode || statusCodes.INTERNAL_SERVER_ERROR,
-    source: propertyName ? { pointer: 'data/attributes/' + propertyName } : '',
+    source: propertyName ? { pointer: 'data/attributes/' + propertyName } : {},
     title: errorName || '',
     code: errorCode || '',
     detail: errorDetail || ''
   }
+
+  if (errorStackInResponse && errorStack) {
+    out.source.stack = errorStack
+  }
+
+  return out
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,6 +3,7 @@
 var debug
 var errorStackInResponse
 var statusCodes = require('http-status-codes')
+var _ = require('lodash')
 
 module.exports = function (app, options) {
   debug = options.debug
@@ -51,7 +52,7 @@ function JSONAPIErrorHandler (err, req, res, next) {
         err.details.messages[key][0],
         err.details.codes[key][0],
         err.name,
-        key
+        { pointer: 'data/attributes/' + key }
       )
     })
   } else if (err.message) {
@@ -81,8 +82,24 @@ function JSONAPIErrorHandler (err, req, res, next) {
       err.name = 'BadRequest'
     }
 
+    var errorSource = err.source && typeof err.source === 'object'
+      ? err.source
+      : {}
+    if (errorStackInResponse) {
+      // We do not want to mutate err.source, so we clone it first
+      errorSource = _.clone(errorSource)
+      errorSource.stack = err.stack
+    }
+
     errors.push(
-      buildErrorResponse(statusCode, err.message, err.code, err.name, null, err.stack)
+      buildErrorResponse(
+        statusCode,
+        err.message,
+        err.code,
+        err.name,
+        errorSource,
+        err.meta
+      )
     )
   } else {
     debug(
@@ -113,8 +130,8 @@ function JSONAPIErrorHandler (err, req, res, next) {
  * @param {String} errorDetail error message for the user, human readable
  * @param {String} errorCode internal system error code
  * @param {String} errorName error title for the user, human readable
- * @param {String} propertyName for validation errors, name of property validation refers to
- * @param {String} errorStack Some debbuging informations
+ * @param {String} errorSource Some informations about the source of the issue
+ * @param {String} errorMeta Some custom metas informations to give to the error response
  * @return {Object}
  */
 function buildErrorResponse (
@@ -122,19 +139,19 @@ function buildErrorResponse (
   errorDetail,
   errorCode,
   errorName,
-  propertyName,
-  errorStack
+  errorSource,
+  errorMeta
 ) {
   var out = {
     status: httpStatusCode || statusCodes.INTERNAL_SERVER_ERROR,
-    source: propertyName ? { pointer: 'data/attributes/' + propertyName } : {},
+    source: errorSource || {},
     title: errorName || '',
     code: errorCode || '',
     detail: errorDetail || ''
   }
 
-  if (errorStackInResponse && errorStack) {
-    out.source.stack = errorStack
+  if (errorMeta && typeof errorMeta === 'object') {
+    out.meta = errorMeta
   }
 
   return out

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -130,8 +130,8 @@ function JSONAPIErrorHandler (err, req, res, next) {
  * @param {String} errorDetail error message for the user, human readable
  * @param {String} errorCode internal system error code
  * @param {String} errorName error title for the user, human readable
- * @param {String} errorSource Some informations about the source of the issue
- * @param {String} errorMeta Some custom metas informations to give to the error response
+ * @param {String} errorSource Some information about the source of the issue
+ * @param {String} errorMeta Some custom meta information to give to the error response
  * @return {Object}
  */
 function buildErrorResponse (


### PR DESCRIPTION
Return a `source.stack` property in the error object in the response.
This debug property contains the stack when an unknown error occured if `errorStackInResponse` is enabled.