### PR TITLE
Feature/dynamic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Example:
     "enable": true,
     "handleErrors": true,
     "errorStackInResponse": false,
-    "handleCustomRemote": false,
+    "handleCustomRemoteMethods": false,
     "exclude": [
       {"model": "comment"},
       {"methods": "find"},
@@ -221,19 +221,19 @@ response. It will be stored under the `source.stack` key.
 - Type: `boolean`
 - Default: `false`
 
-### handleCustomRemote
-Allow all (custom) remotes to be serialized by default.
+### handleCustomRemoteMethods
+Allow all (custom) remote methods to be serialized by default.
 
-This option can be overrided with:
-1. `jsonapi` remote option (have highest priority)
-2. `exclude` component option
-3. `include` component option
+This option can be overridden in any of the following ways:
+1. Setting a jsonapi property to true or false in a remote method definition.
+2. Globally adding the remote method to the component's exclude array.
+3. Globally adding the remote method to the component's include array.
 
 #### example
 ```js
 {
   ...
-  "handleCustomRemote": true,
+  "handleCustomRemoteMethods": true,
   ...
 }
 ```
@@ -409,20 +409,17 @@ Only expose foreign keys for the comment model findById method. eg. `GET /api/co
 - Type: `boolean|array`
 - Default: `false`
 
-## Custom remote
+## Custom remote methods
 
-### `jsonapi` remote options
-Sometime you need to control if custom remote should be serialized or not.
-**By default a custom remote will NOT be handled by JSONApi.**
+### `jsonapi` remote method options
+Sometimes you need to be able to control when a custom remote method should be handled by the component. By default, `loopback-component-jsonapi` will not handle (serialize or deserialize) custom remote methods. In order to tell the component to handle a custom remote method, you have the following options (In priority order):
 
-To enabled/disable JSONApi for specific remotes, you have multiple solutions:
+1. Set `jsonapi` to `true` when defining a custom remote method.
+2. Add the methods name to the component's `exclude` array setting. (see above)
+3. Add the methods name to the component's `include` array setting. (see above)
+4. Set `handleCustomRemoteMethods` to `true` in the component's settings. (see above)
 
-1. Use `jsonapi` remote option
-2. Use `exlude` on component options (see above)
-3. Use `include` on component options (see above)
-4. Use `handleCustomRemote` on component options (see above)
-
-**This option has precedence** and it forces the remote to BE or to NOT BE deserialized/serialized by JSONApi.
+This option takes precedence and sets the component to handle or not handle the custom remote method.
 
 #### examples
 ```js
@@ -431,7 +428,7 @@ Post.remoteMethod('greet', {
   returns: { root: true }
 })
 ```
-Ensure the response of `Post.greet` will follow the JSONApi format.
+Ensures that the response from Post.greet will follow JSONApi format.
 
 ```js
 Post.remoteMethod('greet', {
@@ -439,13 +436,13 @@ Post.remoteMethod('greet', {
   returns: { arg: 'greeting', type: 'string' }
 })
 ```
-Ensure the response of `Post.greet` will not follow the JSONApi format.
+Ensures that the response from Post.greet will never follow JSONApi format.
 
 #### Note
-You should always pass `root: true` to the `returns` object when you use JSONApi, especialy when you expect to respond with an array.
+You must always pass `root: true` to the `returns` object when using `loopback-component-jsonapi`. This is especialy important when you expect the response to be an array.
 
-### Override serialization type
-You may want for a custom method of a given model to return instance(s) from another model. When you do so, you need to enforce the return `type` of this other model in the definition of the remote method.
+### Overriding serialization type
+When `loopback-component-jsonapi` serializes a custom remote method, by default it will assume that the data being serialized is of the same type as the model the custom remote method is being defined on. Eg. For a remote method on a `Comment` model, it will be assumed that the data being returned from the remote method will be a comment or an array of comments. When this is not the case, you will need to set the type property in the `returns` object in the remote method definition.
 
 *If an unknown type or no type are given, the model name will be used.*
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Example:
     "enable": true,
     "handleErrors": true,
     "errorStackInResponse": false,
+    "handleCustomRemote": false,
     "exclude": [
       {"model": "comment"},
       {"methods": "find"},
@@ -213,6 +214,26 @@ response. It will be stored under the `source.stack` key.
 {
   ...
   "errorStackInResponse": NODE_ENV === 'development',
+  ...
+}
+```
+
+- Type: `boolean`
+- Default: `false`
+
+### handleCustomRemote
+Allow all (custom) remotes to be serialized by default.
+
+This option can be overrided with:
+1. `jsonapi` remote option (have highest priority)
+2. `exclude` component option
+3. `include` component option
+
+#### example
+```js
+{
+  ...
+  "handleCustomRemote": true,
   ...
 }
 ```
@@ -387,6 +408,55 @@ Only expose foreign keys for the comment model findById method. eg. `GET /api/co
 
 - Type: `boolean|array`
 - Default: `false`
+
+## Custom remote
+
+### `jsonapi` remote options
+Sometime you need to control if custom remote should be serialized or not.
+**By default a custom remote will NOT be handled by JSONApi.**
+
+To enabled/disable JSONApi for specific remotes, you have multiple solutions:
+
+1. Use `jsonapi` remote option
+2. Use `exlude` on component options (see above)
+3. Use `include` on component options (see above)
+4. Use `handleCustomRemote` on component options (see above)
+
+**This option has precedence** and it forces the remote to BE or to NOT BE deserialized/serialized by JSONApi.
+
+#### examples
+```js
+Post.remoteMethod('greet', {
+  jsonapi: true
+  returns: { root: true }
+})
+```
+Ensure the response of `Post.greet` will follow the JSONApi format.
+
+```js
+Post.remoteMethod('greet', {
+  jsonapi: false
+  returns: { arg: 'greeting', type: 'string' }
+})
+```
+Ensure the response of `Post.greet` will not follow the JSONApi format.
+
+#### Note
+You should always pass `root: true` to the `returns` object when you use JSONApi, especialy when you expect to respond with an array.
+
+### Override serialization type
+You may want for a custom method of a given model to return instance(s) from another model. When you do so, you need to enforce the return `type` of this other model in the definition of the remote method.
+
+*If an unknown type or no type are given, the model name will be used.*
+
+#### example
+
+```js
+Post.remoteMethod('prototype.ownComments', {
+  jsonapi: true
+  returns: { root: true, type: 'comment' }
+})
+```
 
 ## Custom Serialization
 For occasions where you need greater control over the serialization process, you can implement a custom serialization function for each model as needed. This function will be used instead of the regular serialization process.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -235,7 +235,7 @@ function shouldApplyJsonApi (ctx, options) {
   }
 
   // a default option can be set in component-config
-  return !!options.handleCustomRemote
+  return !!options.handleCustomRemoteMethods
 }
 
 function shouldNotApplyJsonApi (ctx, options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,6 +230,7 @@ function shouldApplyJsonApi (ctx, options) {
       if (!model && methods === methodName) return true
       if (model === modelName && methods === methodName) return true
       if (model === modelName && _.includes(methods, methodName)) return true
+      if (!model && _.includes(methods, methodName)) return true
     }
   }
 
@@ -256,6 +257,7 @@ function shouldNotApplyJsonApi (ctx, options) {
     if (!model && methods === methodName) return true
     if (model === modelName && methods === methodName) return true
     if (model === modelName && _.includes(methods, methodName)) return true
+    if (!model && _.includes(methods, methodName)) return true
   }
 
   return false

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -148,7 +148,7 @@ function getTypeFromContext (context) {
 
   const returns = [].concat(context.method.returns)
   for (var i = 0, l = returns.length; i < l; i++) {
-    if (typeof returns[i] === 'object' && returns[i].root === true) continue
+    if (typeof returns[i] !== 'object' || returns[i].root !== true) continue
     return returns[i].type
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,7 @@ module.exports = {
   buildModelUrl: buildModelUrl,
   clone: clone,
   getModelFromContext: getModelFromContext,
+  getTypeFromContext: getTypeFromContext,
   getRelationsFromContext: getRelationsFromContext,
   hostFromContext: hostFromContext,
   modelNameFromContext: modelNameFromContext,
@@ -126,8 +127,30 @@ function urlFromContext (context) {
  * @return {Object}
  */
 function getModelFromContext (context, app) {
+  var type = getTypeFromContext(context)
+  if (app.models[type]) return app.models[type]
+
   var name = modelNameFromContext(context)
   return app.models[name]
+}
+
+/**
+ * Returns a model type from the context object.
+ * Infer the type from the `root` returns in the remote.
+ * @public
+ * @memberOf {Utils}
+ * @param {Object} context
+ * @param {Object} app
+ * @return {String}
+ */
+function getTypeFromContext (context) {
+  if (!context.method.returns) return undefined
+
+  const returns = [].concat(context.method.returns)
+  for (var i = 0, l = returns.length; i < l; i++) {
+    if (typeof returns[i] === 'object' && returns[i].root === true) continue
+    return returns[i].type
+  }
 }
 
 /**
@@ -192,24 +215,32 @@ function buildModelUrl (protocol, host, apiRoot, modelName, id) {
 }
 
 function shouldApplyJsonApi (ctx, options) {
-  if (!options.include) return false
+  // include on remote have higher priority
+  if (ctx.method.jsonapi) return !!ctx.method.jsonapi
 
   var modelName = ctx.method.sharedClass.name
   var methodName = ctx.method.name
   var model
   var methods
-  for (var i = 0; i < options.include.length; i++) {
-    model = options.include[i].model
-    methods = options.include[i].methods
-    if (model === modelName && !methods) return true
-    if (!model && methods === methodName) return true
-    if (model === modelName && methods === methodName) return true
-    if (model === modelName && _.includes(methods, methodName)) return true
+  if (options.include) {
+    for (var i = 0; i < options.include.length; i++) {
+      model = options.include[i].model
+      methods = options.include[i].methods
+      if (model === modelName && !methods) return true
+      if (!model && methods === methodName) return true
+      if (model === modelName && methods === methodName) return true
+      if (model === modelName && _.includes(methods, methodName)) return true
+    }
   }
-  return false
+
+  // a default option can be set in component-config
+  return !!options.handleCustomRemote
 }
 
 function shouldNotApplyJsonApi (ctx, options) {
+  // exclude on remote have higher priority
+  if (ctx.method.jsonapi === false) return true
+
   // handle options.exclude
   if (!options.exclude) return false
 
@@ -217,6 +248,7 @@ function shouldNotApplyJsonApi (ctx, options) {
   var methodName = ctx.method.name
   var model
   var methods
+
   for (var i = 0; i < options.exclude.length; i++) {
     model = options.exclude[i].model
     methods = options.exclude[i].methods
@@ -225,6 +257,7 @@ function shouldNotApplyJsonApi (ctx, options) {
     if (model === modelName && methods === methodName) return true
     if (model === modelName && _.includes(methods, methodName)) return true
   }
+
   return false
 }
 

--- a/test/remoteMethods.test.js
+++ b/test/remoteMethods.test.js
@@ -185,6 +185,7 @@ describe('loopback json api remote methods', function () {
             expect(err).to.equal(null)
             expect(res.body).to.be.an('object')
             expect(res.body.data).to.be.an('array').with.lengthOf(1)
+            expect(res.body.data[0].type).to.equal('archives')
             expect(res.body.data[0].id).to.equal(archiveData.id + '')
             expect(res.body.data[0].attributes).to.deep.equal({
               raw: archiveData.raw,
@@ -205,6 +206,7 @@ describe('loopback json api remote methods', function () {
 
         expect(res.body.data).to.be.an('object')
         expect(res.body.data.id).to.equal(postData.id + '')
+        expect(res.body.data.type).to.equal('posts')
         expect(res.body.data.attributes).to.deep.equal({
           title: postData.title,
           content: postData.content

--- a/test/remoteMethods.test.js
+++ b/test/remoteMethods.test.js
@@ -4,31 +4,98 @@ var request = require('supertest')
 var loopback = require('loopback')
 var expect = require('chai').expect
 var JSONAPIComponent = require('../')
-var app, Post
+var app, Post, Archive
 
-describe('loopback json api remote methods', function () {
-  beforeEach(function () {
+describe.only('loopback json api remote methods', function () {
+  var autocompleteTitleData = ['Post 1', 'Post 2']
+
+  var archiveData = {
+    id: 10,
+    raw: {
+      id: 1,
+      title: 'Ancient Post 1',
+      content: 'Ancient Content of Post 1'
+    },
+    createdAt: Date.now()
+  }
+
+  var postData = {
+    id: 1,
+    title: 'Post 1',
+    content: 'Content of Post 1'
+  }
+
+  beforeEach(function (done) {
     app = loopback()
     app.set('legacyExplorer', false)
     var ds = loopback.createDataSource('memory')
+
+    Archive = ds.createModel('archive', {
+      id: { type: Number, id: true },
+      raw: Object,
+      createAt: Date
+    })
+
     Post = ds.createModel('post', {
       id: { type: Number, id: true },
       title: String,
       content: String
     })
+
     Post.greet = function (msg, cb) {
       cb(null, 'Greetings... ' + msg)
     }
+
+    Post.last = function (cb) {
+      Post.findOne({}, cb)
+    }
+
+    Post.autocomplete = function (q, cb) {
+      cb(null, autocompleteTitleData)
+    }
+
+    Post.prototype.findArchives = function (cb) {
+      Archive.find({}, cb)
+    }
+
     Post.remoteMethod('greet', {
       accepts: { arg: 'msg', type: 'string' },
       returns: { arg: 'greeting', type: 'string' }
     })
+
+    Post.remoteMethod('last', {
+      returns: { root: true },
+      http: { verb: 'get' }
+    })
+
+    Post.remoteMethod('autocomplete', {
+      jsonapi: false,
+      accepts: { arg: 'q', type: 'string', http: { source: 'query' } },
+      returns: { root: true, type: 'array' },
+      http: { path: '/autocomplete', verb: 'get' }
+    })
+
+    Post.remoteMethod('prototype.findArchives', {
+      jsonapi: true,
+      returns: { root: true, type: 'archive' },
+      http: { path: '/archives' }
+    })
+
     app.model(Post)
+    app.model(Archive)
     app.use(loopback.rest())
-    JSONAPIComponent(app)
+
+    Promise.all([Archive.create(archiveData), Post.create(postData)])
+      .then(function () {
+        done()
+      })
   })
 
-  describe('remote method for application/json', function () {
+  describe('for application/json', function () {
+    beforeEach(function () {
+      JSONAPIComponent(app)
+    })
+
     it('POST /posts/greet should return remote method message', function (done) {
       request(app)
         .post('/posts/greet')
@@ -42,4 +109,96 @@ describe('loopback json api remote methods', function () {
         })
     })
   })
+
+  describe('should serialize with `jsonapi: true`', function () {
+    beforeEach(function () {
+      JSONAPIComponent(app)
+    })
+
+    testAutocompleteJsonAPI()
+    testArchivesJsonAPI()
+  })
+
+  describe('when `serializeCustomRemote` is set', function (done) {
+    beforeEach(function () {
+      JSONAPIComponent(app, { handleCustomRemote: true })
+    })
+
+    testAutocompleteJsonAPI()
+    testArchivesJsonAPI()
+    testLastJsonAPI()
+  })
+
+  /* Static test */
+  function testAutocompleteJsonAPI () {
+    it(
+      'GET /posts/autocomplete should return an array with raw format (`jsonapi: false` has precedence)',
+      function (done) {
+        request(app)
+          .get('/posts/autocomplete')
+          .expect(200)
+          .end(function (err, res) {
+            expect(err).to.equal(null)
+            expect(res.body).to.deep.equal(autocompleteTitleData)
+            done()
+          })
+      }
+    )
+  }
+
+  /* Static test */
+  function testArchivesJsonAPI () {
+    it(
+      'GET /posts/1/archives should return a JSONApi list of Archive (`jsonapi: true` has precedence)',
+      function (done) {
+        request(app)
+          .get('/posts/1/archives')
+          .expect(200)
+          .end(function (err, res) {
+            expect(err).to.equal(null)
+            expect(res.body).to.be.an('object')
+            expect(res.body.data).to.be.an('array').with.lengthOf(1)
+            expect(res.body.data[0].id).to.equal(archiveData.id + '')
+            expect(res.body.data[0].attributes).to.deep.equal({
+              raw: archiveData.raw,
+              createdAt: archiveData.createdAt
+            })
+
+            done()
+          })
+      }
+    )
+  }
+
+  /* Static test */
+  function testLastJsonAPI () {
+    it('GET /posts/last should return a JSONApi Post', function (done) {
+      request(app).get('/posts/last').expect(200).end(function (err, res) {
+        expect(err).to.equal(null)
+
+        expect(res.body.data).to.be.an('object')
+        expect(res.body.data.id).to.equal(postData.id + '')
+        expect(res.body.data.attributes).to.deep.equal({
+          title: postData.title,
+          content: postData.content
+        })
+
+        done()
+      })
+    })
+  }
+
+  /* Static test */
+  function testLastRaw () {
+    it(
+      'GET /posts/last should return a raw Post (exclude is more important than include and handleCustomRemote)',
+      function (done) {
+        request(app).get('/posts/last').expect(200).end(function (err, res) {
+          expect(err).to.equal(null)
+          expect(res.body).to.deep.equal(postData)
+          done()
+        })
+      }
+    )
+  }
 })

--- a/test/remoteMethods.test.js
+++ b/test/remoteMethods.test.js
@@ -6,7 +6,7 @@ var expect = require('chai').expect
 var JSONAPIComponent = require('../')
 var app, Post, Archive
 
-describe.only('loopback json api remote methods', function () {
+describe('loopback json api remote methods', function () {
   var autocompleteTitleData = ['Post 1', 'Post 2']
 
   var archiveData = {
@@ -126,6 +126,33 @@ describe.only('loopback json api remote methods', function () {
 
     testAutocompleteJsonAPI()
     testArchivesJsonAPI()
+    testLastJsonAPI()
+  })
+
+  describe('when `exclude` is set', function (done) {
+    beforeEach(function () {
+      JSONAPIComponent(app, {
+        handleCustomRemote: true,
+        exclude: [{ methods: ['last', 'autocomplete', 'archives'] }],
+        include: [{ methods: 'last' }]
+      })
+    })
+
+    testArchivesJsonAPI()
+    testAutocompleteJsonAPI()
+    testLastRaw()
+  })
+
+  describe('when `include` is set', function (done) {
+    beforeEach(function () {
+      JSONAPIComponent(app, {
+        handleCustomRemote: false,
+        include: [{ methods: 'last' }]
+      })
+    })
+
+    testArchivesJsonAPI()
+    testAutocompleteJsonAPI()
     testLastJsonAPI()
   })
 

--- a/test/remoteMethods.test.js
+++ b/test/remoteMethods.test.js
@@ -121,7 +121,7 @@ describe('loopback json api remote methods', function () {
 
   describe('when `serializeCustomRemote` is set', function (done) {
     beforeEach(function () {
-      JSONAPIComponent(app, { handleCustomRemote: true })
+      JSONAPIComponent(app, { handleCustomRemoteMethods: true })
     })
 
     testAutocompleteJsonAPI()
@@ -132,7 +132,7 @@ describe('loopback json api remote methods', function () {
   describe('when `exclude` is set', function (done) {
     beforeEach(function () {
       JSONAPIComponent(app, {
-        handleCustomRemote: true,
+        handleCustomRemoteMethods: true,
         exclude: [{ methods: ['last', 'autocomplete', 'archives'] }],
         include: [{ methods: 'last' }]
       })
@@ -146,7 +146,7 @@ describe('loopback json api remote methods', function () {
   describe('when `include` is set', function (done) {
     beforeEach(function () {
       JSONAPIComponent(app, {
-        handleCustomRemote: false,
+        handleCustomRemoteMethods: false,
         include: [{ methods: 'last' }]
       })
     })
@@ -220,7 +220,7 @@ describe('loopback json api remote methods', function () {
   /* Static test */
   function testLastRaw () {
     it(
-      'GET /posts/last should return a raw Post (exclude is more important than include and handleCustomRemote)',
+      'GET /posts/last should return a raw Post (exclude is more important than include and handleCustomRemoteMethods)',
       function (done) {
         request(app).get('/posts/last').expect(200).end(function (err, res) {
           expect(err).to.equal(null)


### PR DESCRIPTION
See changes in README.

* Add an option `handleCustomRemote` to deserialize/serialize custom remote by default
* Fix #45 By allowing a `jsonapi: true | false` option to be given to the custom remote, to force the use or NOT of JSONApi format for this remote
* Fix #45 (in comments) custom returns model types are now handled, and types and relationships and links are now correct for custom remote that does return another model(s)
* Fix an issue I discovered by testing component config exclude/include, when the setting was ignored when no model was given, but methods was an array.

Also add a lot of tests for all this, and updated the README (if @digitalsadhu could checked for typos, that would be great)