### PR TITLE
fix(utils): add condition to isLoopbackInclude

### DIFF
--- a/lib/utilities/relationship-utils.js
+++ b/lib/utilities/relationship-utils.js
@@ -45,7 +45,7 @@ function getInvalidIncludesError (message) {
 }
 
 function isLoopbackInclude (ctx) {
-  return ctx.args && ctx.args.filter
+  return ctx.args && ctx.args.filter && ctx.args.filter.include
 }
 
 function isJSONAPIInclude (req) {


### PR DESCRIPTION
Added an extra condition to `isLoopbackInclude()` to ensure it only returns true if the user passes in an include filter.  This should fix an issue where requests along the lines of `GET /posts?filter[where][id]=123&include=comments` are ignoring the include parameter when there is also a filter param.