### PR TITLE
[BUGFIX] include may not have a .relation and just be a { [modelName]: true } sometimes

### DIFF
--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var _ = require('lodash')
+var utils = require('./utils')
 
 function defaultBeforeDeserialize (options, cb) {
   cb(null, options)
@@ -78,6 +79,17 @@ function belongsToRelationships (options) {
     if (!relationship.data) {
       options.result[fkName] = null
     } else {
+      // https://github.com/digitalsadhu/loopback-component-jsonapi/compare/master...grahambates:loopback-component-jsonapi:master
+      if (serverRelation.polymorphic) {
+        var relatedType = relationship.data.type
+        var modelClass = _.find(model.app.models, function (model) {
+          var plural = utils.pluralForModel(model)
+          return plural === relatedType
+        })
+
+        var discriminator = serverRelation.polymorphic.discriminator
+        options.result[discriminator] = modelClass.modelName
+      }
       options.result[fkName] = relationship.data.id
     }
   })

--- a/lib/utilities/relationship-utils.js
+++ b/lib/utilities/relationship-utils.js
@@ -45,7 +45,7 @@ function getInvalidIncludesError (message) {
 }
 
 function isLoopbackInclude (ctx) {
-  return ctx.args && ctx.args.filter
+  return ctx.args && ctx.args.filter && ctx.args.filter.include
 }
 
 function isJSONAPIInclude (req) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,7 +292,7 @@ function setRequestedIncludes (include) {
       }
 
       if (inc instanceof Object) {
-        return inc.relation
+        return inc.relation || _.findKey(inc, value => value === true)
       }
     })
   }


### PR DESCRIPTION
Used to fail when my model has a default scope in its model.json
```
scope: {
  include: ['model1', 'model2']
}
```
and I make a filter REST API call with
`/api/model?include=model3`

Turns out the requested include was never included in the serialised result because
1. `isLoopbackInclude` checked for an incomplete condition, which overrode `isJSONAPIInclude` -> added `ctx.args.filter.include` to make it correct
2. `setRequestedInclude` did not account for object of type `{ [modelName]: true }` -> made it do so